### PR TITLE
(feature) basic imports support

### DIFF
--- a/ast/src/main/java/smef/ast/BuiltinTypeRef.java
+++ b/ast/src/main/java/smef/ast/BuiltinTypeRef.java
@@ -1,0 +1,27 @@
+package smef.ast;
+
+public class BuiltinTypeRef extends TypeRef {
+
+	private BuiltinTypeRef(String name) {
+		super("", name);
+	}
+
+	public static final TypeRef BOOLEAN = new BuiltinTypeRef("boolean");
+	
+	public static final TypeRef INTEGER = new BuiltinTypeRef("integer");
+	
+	public static final TypeRef DECIMAL = new BuiltinTypeRef("decimal");
+	
+	public static final TypeRef STRING = new BuiltinTypeRef("string");	
+	
+	public static final TypeRef DATE = new BuiltinTypeRef("date");
+	
+	public static final TypeRef DATETIME = new BuiltinTypeRef("datetime");
+	
+	public static final TypeRef TIME = new BuiltinTypeRef("time");
+	
+	public static final TypeRef UUID = new BuiltinTypeRef("uuid");
+	
+	public static final TypeRef URI = new BuiltinTypeRef("uri");
+	
+}

--- a/ast/src/main/java/smef/ast/FieldListDef.java
+++ b/ast/src/main/java/smef/ast/FieldListDef.java
@@ -1,7 +1,18 @@
 package smef.ast;
 
+import static java.util.function.Predicate.isEqual;
+import static smef.ast.BuiltinTypeRef.DATE;
+import static smef.ast.BuiltinTypeRef.DATETIME;
+import static smef.ast.BuiltinTypeRef.TIME;
+import static smef.ast.BuiltinTypeRef.URI;
+import static smef.ast.BuiltinTypeRef.UUID;
+
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public abstract class FieldListDef {
 
@@ -10,4 +21,46 @@ public abstract class FieldListDef {
 	protected FieldListDef(List<FieldDef> fields) {
 		this.fields = Collections.unmodifiableList(fields);
 	}
+	
+	Stream<TypeRef> refStream() {
+		return fields.stream().map(field -> field.type);
+	}
+	
+	public Set<TypeRef> refs() {
+		return refStream()
+				.sorted(
+						(left, right) -> left.toString().compareTo(right.toString()) 
+				).collect(Collectors.toCollection(LinkedHashSet::new));
+	}
+	
+	public boolean hasMany() {
+		return fields.stream().anyMatch(field -> field.quantifier == Quantifier.MANY);
+	}
+	
+	public boolean hasOpt() {
+		return fields.stream().anyMatch(field -> field.quantifier == Quantifier.OPT);
+	}
+	
+	public boolean hasDate() {
+		return refStream().anyMatch(isEqual(DATE));
+	}
+	
+	public boolean hasDateTime() {
+		return refStream().anyMatch(isEqual(DATETIME));
+	}
+	
+	public boolean hasTime() {
+		return refStream().anyMatch(isEqual(TIME));
+	}
+	
+	public boolean hasUuid() {
+		return refStream().anyMatch(isEqual(UUID));
+	}
+	
+	public boolean hasUri() {
+		return refStream().anyMatch(isEqual(URI));
+	}
+	
+	
+	
 }

--- a/ast/src/main/java/smef/ast/MessageDef.java
+++ b/ast/src/main/java/smef/ast/MessageDef.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 public abstract class MessageDef extends FieldListDef {
 
@@ -25,6 +26,10 @@ public abstract class MessageDef extends FieldListDef {
 		this.comments = comments!=null ? comments : NO_COMMENT;
 	}
 	
+	@Override
+	Stream<TypeRef> refStream() {
+		return Stream.concat(traits.stream(), super.refStream());
+	}
 	
 	abstract protected void accept(VConsumer consumer) throws Exception;
 	

--- a/ast/src/main/java/smef/ast/TypeRef.java
+++ b/ast/src/main/java/smef/ast/TypeRef.java
@@ -28,4 +28,8 @@ public class TypeRef {
 	public int hashCode() {
 		return domain.hashCode() * 13 + name.hashCode();
 	}
+	
+	public String toString() {
+		return String.format("%s.%s", domain, name);
+	}
 }

--- a/ast/src/main/java/smef/ast/UnionMessageDef.java
+++ b/ast/src/main/java/smef/ast/UnionMessageDef.java
@@ -3,6 +3,7 @@ package smef.ast;
 import static java.util.Collections.unmodifiableList;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 public class UnionMessageDef extends MessageDef {
 
@@ -11,6 +12,24 @@ public class UnionMessageDef extends MessageDef {
 	public UnionMessageDef(String name, List<String> comments, List<TypeRef> traits, List<FieldDef> fields, List<SimpleMessageDef> cases) {
 		super(name, comments, traits, fields);
 		this.members = unmodifiableList(cases);
+	}
+	
+	@Override
+	Stream<TypeRef> refStream() {
+		return Stream.concat(
+				super.refStream(),
+				members.stream().flatMap(SimpleMessageDef::refStream)
+		);
+	}
+	
+	@Override
+	public boolean hasMany() {
+		return super.hasMany() || members.stream().anyMatch(SimpleMessageDef::hasMany);
+	}
+
+	@Override
+	public boolean hasOpt() {
+		return super.hasOpt() || members.stream().anyMatch(SimpleMessageDef::hasOpt);
 	}
 
 	@Override

--- a/generator/src/main/java/smef/generator/TypeMapper.java
+++ b/generator/src/main/java/smef/generator/TypeMapper.java
@@ -6,6 +6,11 @@ import smef.ast.TypeSpec;
 
 public interface TypeMapper {
 
+	/** Map a type specification to the simple name of the type in the target dialect.
+	 * 
+	 * @param spec the type specification to map.
+	 * @return The simple name of the type for the specification, or empty if no mapping can be found. 
+	 */
 	Optional<String> map(TypeSpec spec);
 	
 }

--- a/generator/src/main/java/smef/generator/handlerbars/HandlerbarsMessageWriter.java
+++ b/generator/src/main/java/smef/generator/handlerbars/HandlerbarsMessageWriter.java
@@ -7,6 +7,7 @@ import com.github.jknack.handlebars.Context;
 import com.github.jknack.handlebars.Template;
 import com.github.jknack.handlebars.context.FieldValueResolver;
 import com.github.jknack.handlebars.context.MapValueResolver;
+import com.github.jknack.handlebars.context.MethodValueResolver;
 
 import smef.ast.MessageDef;
 import smef.ast.SimpleMessageDef;
@@ -62,7 +63,8 @@ public class HandlerbarsMessageWriter implements SmefMessageWriter {
 				.combine("domain", domain)
 				.resolver(
 						FieldValueResolver.INSTANCE,
-						MapValueResolver.INSTANCE
+						MapValueResolver.INSTANCE,
+						MethodValueResolver.INSTANCE
 						)
 				.build();	
 	}

--- a/generator/src/main/java/smef/generator/java/JavaTypeMapper.java
+++ b/generator/src/main/java/smef/generator/java/JavaTypeMapper.java
@@ -2,6 +2,7 @@ package smef.generator.java;
 
 import static smef.ast.Quantifier.MANY;
 
+import java.net.URI;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
@@ -22,30 +23,27 @@ public class JavaTypeMapper implements TypeMapper {
 		singleTypeMappings.put("integer", "int");
 		singleTypeMappings.put("decimal", "float");
 		singleTypeMappings.put("string", "String");
-		singleTypeMappings.put("date", LocalDate.class.getName());
-		singleTypeMappings.put("datetime", OffsetDateTime.class.getName());
-		singleTypeMappings.put("time", OffsetTime.class.getName());
-		singleTypeMappings.put("uuid", UUID.class.getName());
+		singleTypeMappings.put("date", LocalDate.class.getSimpleName());
+		singleTypeMappings.put("datetime", OffsetDateTime.class.getSimpleName());
+		singleTypeMappings.put("time", OffsetTime.class.getSimpleName());
+		singleTypeMappings.put("uuid", UUID.class.getSimpleName());
+		singleTypeMappings.put("uri", URI.class.getSimpleName());
 		
 		multiTypeMappings.put("boolean", Boolean.class.getSimpleName());
 		multiTypeMappings.put("integer", Integer.class.getSimpleName());
 		multiTypeMappings.put("decimal", Float.class.getSimpleName());
 		multiTypeMappings.put("string", String.class.getSimpleName());
-		singleTypeMappings.put("date", LocalDate.class.getName());
-		singleTypeMappings.put("datetime", OffsetDateTime.class.getName());
-		singleTypeMappings.put("time", OffsetTime.class.getName());
-		multiTypeMappings.put("uuid", UUID.class.getName());
+		multiTypeMappings.put("date", LocalDate.class.getSimpleName());
+		multiTypeMappings.put("datetime", OffsetDateTime.class.getSimpleName());
+		multiTypeMappings.put("time", OffsetTime.class.getSimpleName());
+		multiTypeMappings.put("uuid", UUID.class.getSimpleName());
+		multiTypeMappings.put("uri", URI.class.getSimpleName());
 	}
-	private final Map<String, String> domainMappings;
 	
-	
-	private JavaTypeMapper(Map<String, String> domainMappings) {
-		this.domainMappings = domainMappings;
+	private JavaTypeMapper() {
 	}
 
-	public static JavaTypeMapper withDomainMappings(Map<String, String> domainMappings) {
-		return new JavaTypeMapper(domainMappings);
-	}
+	public static JavaTypeMapper INSTANCE = new JavaTypeMapper();
 	
 	@Override
 	public Optional<String> map(TypeSpec spec) {
@@ -56,7 +54,7 @@ public class JavaTypeMapper implements TypeMapper {
 		return Optional.ofNullable(
 			spec.domain == null || spec.domain.isEmpty()
 				? mapUnqualifiedType(spec)
-				: mapDomainType(spec)
+				: spec.name
 		);
 	}
 	
@@ -67,10 +65,4 @@ public class JavaTypeMapper implements TypeMapper {
 		
 		return singleTypeMappings.get(spec.name);
 	}
-	
-	public String mapDomainType(TypeSpec spec) {
-		String pkg = Optional.ofNullable(domainMappings.get(spec.domain)).orElse(spec.domain);
-		return pkg + "." + spec.name;		
-	}
-
 }

--- a/generator/src/main/java/smef/generator/java/SmefJavaDialect.java
+++ b/generator/src/main/java/smef/generator/java/SmefJavaDialect.java
@@ -17,7 +17,7 @@ public class SmefJavaDialect implements SmefDialect {
 	
 	public SmefJavaDialect(Map<String, String> domainToPackage) {
 		this.domainToPackage = domainToPackage;
-		this.typeMapper = JavaTypeMapper.withDomainMappings(domainToPackage);
+		this.typeMapper = JavaTypeMapper.INSTANCE;
 	}
 
 	@Override

--- a/generator/src/main/resources/smef/templates/java/getters.hbs
+++ b/generator/src/main/resources/smef/templates/java/getters.hbs
@@ -3,7 +3,7 @@
 {{> javadoc}}
 */
 {{#eq quantifier.name "MANY"}}
-java.util.List<{{mapType typeSpec}}> {{name}}();
+List<{{mapType typeSpec}}> {{name}}();
 {{^}}
 {{mapType typeSpec}} {{name}}();
 {{/eq}}

--- a/generator/src/main/resources/smef/templates/java/imports.hbs
+++ b/generator/src/main/resources/smef/templates/java/imports.hbs
@@ -1,0 +1,24 @@
+{{#hasMany}}
+import java.util.List;
+{{/hasMany}}
+{{#hasUuid}}
+import java.util.UUID;
+{{/hasUuid}}
+{{#hasDate}}
+import java.time.LocalDate;
+{{/hasDate}}
+{{#hasDateTime}}
+import java.time.OffsetDateTime;
+{{/hasDateTime}}
+{{#hasTime}}
+import java.time.OffsetTime;
+{{/hasTime}}
+{{#hasUri}}
+import java.net.Uri;
+{{/hasUri}}
+
+{{#refs}}
+{{#if domain}}
+import {{mapDomain domain}}.{{name}};
+{{/if}}
+{{/refs}}

--- a/generator/src/main/resources/smef/templates/java/simple.hbs
+++ b/generator/src/main/resources/smef/templates/java/simple.hbs
@@ -1,5 +1,7 @@
 package {{mapDomain domain}};
 
+{{> imports}}
+
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import org.immutables.value.Value;

--- a/generator/src/main/resources/smef/templates/java/trait.hbs
+++ b/generator/src/main/resources/smef/templates/java/trait.hbs
@@ -1,5 +1,7 @@
 package {{mapDomain domain}};
 
+{{> imports}}
+
 /**
  {{> javadoc}}
  */

--- a/generator/src/main/resources/smef/templates/java/union.hbs
+++ b/generator/src/main/resources/smef/templates/java/union.hbs
@@ -3,7 +3,7 @@ package {{mapDomain domain}};
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
-
+{{> imports}}
 
 import org.immutables.value.Value;
 import org.immutables.value.Value.Style.ImplementationVisibility;


### PR DESCRIPTION
Generated Java code uses imports rather than fully qualified type names.

As a consequence, TypeMapper now only retrun the simple
(unqualified) type name corresponding to a Smef type sepcification.

A possible caveat with this approach is that it assumes that there
are no simple name collisions. As the assumption is true in most
cases, this will be addressed later.